### PR TITLE
Fix incorrect incorrect owner argument to sales command in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Query for collection data en masse with JSON and CSV output for data analysis, a
 
  * `nft tokens --owner tyson.eth,isiain.eth --limit 10000`
 
- * `nft sales --owner isiain.eth --limit 100`
+ * `nft sales --seller isiain.eth --limit 100`
 ### What powers this?
 
 The backend for this is powered by `https://api.zora.co/graphql`.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Query for collection data en masse with JSON and CSV output for data analysis, a
  * `nft tokens --owner tyson.eth,isiain.eth --limit 10000`
 
  * `nft sales --seller isiain.eth --limit 100`
+
 ### What powers this?
 
 The backend for this is powered by `https://api.zora.co/graphql`.
-


### PR DESCRIPTION
The README example of how to call the `sales` command uses the argument `--owner` but it should be `--seller`. This PR fixes that!